### PR TITLE
Change beam.version to 0.4.0-incubating-SNAPSHOT in pom.xml

### DIFF
--- a/BeamTutorial/pom.xml
+++ b/BeamTutorial/pom.xml
@@ -9,7 +9,7 @@
 
 
   <properties>
-    <beam.version>0.3.0-incubating-SNAPSHOT</beam.version>
+    <beam.version>0.4.0-incubating-SNAPSHOT</beam.version>
     <slf4j.version>1.7.5</slf4j.version>
     <junit.version>4.8.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
The current `beam.version=0.3.0-incubating-SNAPSHOT` leads to `mvn package` `BUILD FAILURE` because of the update in https://repository.apache.org/content/repositories/snapshots/org/apache/beam, which should be updated to `0.4.0-incubating-SNAPSHOT`